### PR TITLE
Fixed encoding of non-ASCII text

### DIFF
--- a/pyvideo_scrape.py
+++ b/pyvideo_scrape.py
@@ -17,6 +17,7 @@ import youtube_dl
 from loguru import logger
 
 JSON_FORMAT_KWARGS = {
+    'ensure_ascii': False,
     'indent': 2,
     'separators': (',', ': '),
     'sort_keys': True,


### PR DESCRIPTION
Without this commit all international symbols are escaped leading to unreadable JSON fields, such as:

https://github.com/pyvideo/data/blob/c605a6bb27cb0027146cb015f0b9de133add3508/pycon-odessa-2019/videos/aleksei-borisenko-setevaia-programmiruemost-s-ispolzovaniem-python-ua.json#L20

This causes invalid URLs generation on pyvideo.org web site. Check link to the second video on https://pyvideo.org/search.html?q=odessa+2019 which is https://pyvideo.org/pycon-odessa-2019/-python-ua.html 404